### PR TITLE
Fix RefreshTokenGrantTokenServiceTest 

### DIFF
--- a/oauth2-server-core/src/test/java/nl/myndocs/oauth2/RefreshTokenGrantTokenServiceTest.kt
+++ b/oauth2-server-core/src/test/java/nl/myndocs/oauth2/RefreshTokenGrantTokenServiceTest.kt
@@ -70,7 +70,7 @@ internal class RefreshTokenGrantTokenServiceTest {
         every { tokenStore.refreshToken(refreshToken) } returns token
         every { identityService.identityOf(client, username) } returns identity
         every { refreshTokenConverter.convertToToken(username, clientId, scopes) } returns newRefreshToken
-        every { accessTokenConverter.convertToToken(username, clientId, scopes, newRefreshToken) } returns accessToken
+        every { accessTokenConverter.convertToToken(username, clientId, scopes, token) } returns accessToken
 
         tokenService.refresh(refreshTokenRequest)
 


### PR DESCRIPTION
The test failed for me, it seems like `accessTokenConverter.convertToToken` is supposed to take the old refresh token and create a new access token from it, but the mock expects the new refresh token as input