### PR TITLE
Add support for client credentials grant

### DIFF
--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/TokenService.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/TokenService.kt
@@ -13,6 +13,8 @@ interface TokenService {
 
     fun authorize(authorizationCodeRequest: AuthorizationCodeRequest): TokenResponse
 
+    fun authorize(clientCredentialsRequest: ClientCredentialsRequest): TokenResponse
+
     fun refresh(refreshTokenRequest: RefreshTokenRequest): TokenResponse
 
     fun redirect(

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/client/AuthorizedGrantType.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/client/AuthorizedGrantType.kt
@@ -5,4 +5,5 @@ object AuthorizedGrantType {
     const val REFRESH_TOKEN = "refresh_token"
     const val PASSWORD = "password"
     const val AUTHORIZATION_CODE = "authorization_code"
+    const val CLIENT_CREDENTIALS = "client_credentials"
 }

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/request/ClientCredentialsRequest.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/request/ClientCredentialsRequest.kt
@@ -1,0 +1,9 @@
+package nl.myndocs.oauth2.request
+
+data class ClientCredentialsRequest(
+    override val clientId: String?,
+    override val clientSecret: String?,
+    val scope: String?
+) : ClientRequest{
+    val grant_type = "client_credentials"
+}

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/AccessToken.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/AccessToken.kt
@@ -6,7 +6,7 @@ data class AccessToken(
         val accessToken: String,
         val tokenType: String,
         override val expireTime: Instant,
-        val username: String,
+        val username: String?,
         val clientId: String,
         val scopes: Set<String>,
         val refreshToken: RefreshToken?

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/RefreshToken.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/RefreshToken.kt
@@ -5,7 +5,7 @@ import java.time.Instant
 data class RefreshToken(
         val refreshToken: String,
         override val expireTime: Instant,
-        val username: String,
+        val username: String?,
         val clientId: String,
         val scopes: Set<String>
 ) : ExpirableToken

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/AccessTokenConverter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/AccessTokenConverter.kt
@@ -4,5 +4,5 @@ import nl.myndocs.oauth2.token.AccessToken
 import nl.myndocs.oauth2.token.RefreshToken
 
 interface AccessTokenConverter {
-    fun convertToToken(username: String, clientId: String, requestedScopes: Set<String>, refreshToken: RefreshToken?): AccessToken
+    fun convertToToken(username: String?, clientId: String, requestedScopes: Set<String>, refreshToken: RefreshToken?): AccessToken
 }

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/RefreshTokenConverter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/RefreshTokenConverter.kt
@@ -3,5 +3,5 @@ package nl.myndocs.oauth2.token.converter
 import nl.myndocs.oauth2.token.RefreshToken
 
 interface RefreshTokenConverter {
-    fun convertToToken(username: String, clientId: String, requestedScopes: Set<String>): RefreshToken
+    fun convertToToken(username: String?, clientId: String, requestedScopes: Set<String>): RefreshToken
 }

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/UUIDAccessTokenConverter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/UUIDAccessTokenConverter.kt
@@ -9,7 +9,7 @@ class UUIDAccessTokenConverter(
         private val accessTokenExpireInSeconds: Int = 3600
 ) : AccessTokenConverter {
 
-    override fun convertToToken(username: String, clientId: String, requestedScopes: Set<String>, refreshToken: RefreshToken?): AccessToken {
+    override fun convertToToken(username: String?, clientId: String, requestedScopes: Set<String>, refreshToken: RefreshToken?): AccessToken {
         return AccessToken(
                 UUID.randomUUID().toString(),
                 "bearer",

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/UUIDRefreshTokenConverter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/UUIDRefreshTokenConverter.kt
@@ -7,7 +7,7 @@ import java.util.*
 class UUIDRefreshTokenConverter(
         private val refreshTokenExpireInSeconds: Int = 86400
 ) : RefreshTokenConverter {
-    override fun convertToToken(username: String, clientId: String, requestedScopes: Set<String>): RefreshToken {
+    override fun convertToToken(username: String?, clientId: String, requestedScopes: Set<String>): RefreshToken {
         return RefreshToken(
                 UUID.randomUUID().toString(),
                 Instant.now().plusSeconds(refreshTokenExpireInSeconds.toLong()),

--- a/oauth2-server-core/src/test/java/nl/myndocs/oauth2/ClientCredentialsTokenServiceTest.kt
+++ b/oauth2-server-core/src/test/java/nl/myndocs/oauth2/ClientCredentialsTokenServiceTest.kt
@@ -1,0 +1,106 @@
+package nl.myndocs.oauth2
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import nl.myndocs.oauth2.client.AuthorizedGrantType
+import nl.myndocs.oauth2.client.Client
+import nl.myndocs.oauth2.client.ClientService
+import nl.myndocs.oauth2.exception.InvalidClientException
+import nl.myndocs.oauth2.identity.IdentityService
+import nl.myndocs.oauth2.request.ClientCredentialsRequest
+import nl.myndocs.oauth2.token.AccessToken
+import nl.myndocs.oauth2.token.RefreshToken
+import nl.myndocs.oauth2.token.TokenStore
+import nl.myndocs.oauth2.token.converter.AccessTokenConverter
+import nl.myndocs.oauth2.token.converter.CodeTokenConverter
+import nl.myndocs.oauth2.token.converter.RefreshTokenConverter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+
+@ExtendWith(MockKExtension::class)
+internal class ClientCredentialsTokenServiceTest {
+    @MockK
+    lateinit var identityService: IdentityService
+    @MockK
+    lateinit var clientService: ClientService
+    @RelaxedMockK
+    lateinit var tokenStore: TokenStore
+    @MockK
+    lateinit var accessTokenConverter: AccessTokenConverter
+    @MockK
+    lateinit var refreshTokenConverter: RefreshTokenConverter
+    @MockK
+    lateinit var codeTokenConverter: CodeTokenConverter
+
+    @InjectMockKs
+    lateinit var tokenService: Oauth2TokenService
+
+    private val clientId = "client-foo"
+    private val clientSecret = "client-secret"
+    private val scope = "scope1"
+    private val scopes = setOf(scope)
+    private val clientCredentialsRequest = ClientCredentialsRequest(clientId, clientSecret, scope)
+
+    @Test
+    fun validClientCredentialsGrant() {
+        val client = Client(clientId, emptySet(), emptySet(), setOf(AuthorizedGrantType.CLIENT_CREDENTIALS))
+        val refreshToken = RefreshToken("test", Instant.now(), null, clientId, scopes)
+        val accessToken = AccessToken("test", "bearer", Instant.now(), null, clientId, scopes, refreshToken)
+
+        every { clientService.clientOf(clientId) } returns client
+        every { clientService.validClient(client, clientSecret) } returns true
+        every { refreshTokenConverter.convertToToken(null, clientId, scopes) } returns refreshToken
+        every { accessTokenConverter.convertToToken(null, clientId, scopes, refreshToken) } returns accessToken
+
+        tokenService.authorize(clientCredentialsRequest)
+
+        verify { tokenStore.storeAccessToken(accessToken) }
+    }
+
+    @Test
+    fun nonExistingClientException() {
+        every { clientService.clientOf(clientId) } returns null
+
+        Assertions.assertThrows(
+            InvalidClientException::class.java
+        ) { tokenService.authorize(clientCredentialsRequest) }
+    }
+
+    @Test
+    fun invalidClientException() {
+        val client = Client(clientId, emptySet(), emptySet(), setOf(AuthorizedGrantType.CLIENT_CREDENTIALS))
+        every { clientService.clientOf(clientId) } returns client
+        every { clientService.validClient(client, clientSecret) } returns false
+
+        Assertions.assertThrows(
+            InvalidClientException::class.java
+        ) { tokenService.authorize(clientCredentialsRequest) }
+    }
+
+    @Test
+    fun clientScopesAsFallback() {
+        val clientCredentialsRequest = ClientCredentialsRequest(
+            clientId,
+            clientSecret,
+            null
+        )
+
+        val client = Client(clientId, setOf("scope1", "scope2"), setOf(), setOf(AuthorizedGrantType.CLIENT_CREDENTIALS))
+        val requestScopes = setOf("scope1", "scope2")
+        val refreshToken = RefreshToken("test", Instant.now(), null, clientId, requestScopes)
+        val accessToken = AccessToken("test", "bearer", Instant.now(), null, clientId, requestScopes, refreshToken)
+
+        every { clientService.clientOf(clientId) } returns client
+        every { clientService.validClient(client, clientSecret) } returns true
+        every { refreshTokenConverter.convertToToken(null, clientId, requestScopes) } returns refreshToken
+        every { accessTokenConverter.convertToToken(null, clientId, requestScopes, refreshToken) } returns accessToken
+
+        tokenService.authorize(clientCredentialsRequest)
+    }
+}


### PR DESCRIPTION
Implementing the client credentials grant.  

This required setting the username field to be nullable as client_credentials grant implies no user.  I've left username as non-null for the code token as you can never have a code token when using client credentials