### PR TITLE
Fix refresh token always being reused 

### DIFF
--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/Oauth2TokenService.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/Oauth2TokenService.kt
@@ -143,7 +143,11 @@ class Oauth2TokenService(
                 refreshToken.username,
                 refreshToken.clientId,
                 refreshToken.scopes,
-                refreshToken
+                refreshTokenConverter.convertToToken(
+                    refreshToken.username,
+                    refreshToken.clientId,
+                    refreshToken.scopes
+                )
         )
 
         tokenStore.storeAccessToken(accessToken)

--- a/oauth2-server-core/src/test/java/nl/myndocs/oauth2/RefreshTokenGrantTokenServiceTest.kt
+++ b/oauth2-server-core/src/test/java/nl/myndocs/oauth2/RefreshTokenGrantTokenServiceTest.kt
@@ -61,7 +61,7 @@ internal class RefreshTokenGrantTokenServiceTest {
     fun validRefreshToken() {
         val client = Client(clientId, setOf("scope1", "scope2"), setOf(), setOf(AuthorizedGrantType.REFRESH_TOKEN))
         val token = RefreshToken("test", Instant.now(), username, clientId, scopes)
-        val newRefreshToken = RefreshToken("test", Instant.now(), username, clientId, scopes)
+        val newRefreshToken = RefreshToken("new-test", Instant.now(), username, clientId, scopes)
         val accessToken = AccessToken("test", "bearer", Instant.now(), username, clientId, scopes, newRefreshToken)
         val identity = Identity(username)
 
@@ -70,7 +70,7 @@ internal class RefreshTokenGrantTokenServiceTest {
         every { tokenStore.refreshToken(refreshToken) } returns token
         every { identityService.identityOf(client, username) } returns identity
         every { refreshTokenConverter.convertToToken(username, clientId, scopes) } returns newRefreshToken
-        every { accessTokenConverter.convertToToken(username, clientId, scopes, token) } returns accessToken
+        every { accessTokenConverter.convertToToken(username, clientId, scopes, newRefreshToken) } returns accessToken
 
         tokenService.refresh(refreshTokenRequest)
 


### PR DESCRIPTION
An attempt at fixing #29 - this makes the implementor create a new refresh token each time - I don't think it really allows them to reuse the old refresh token though - is that desired?