### PR TITLE
Allow refresh token reuse

### DIFF
--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/Oauth2TokenService.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/Oauth2TokenService.kt
@@ -143,11 +143,7 @@ class Oauth2TokenService(
                 refreshToken.username,
                 refreshToken.clientId,
                 refreshToken.scopes,
-                refreshTokenConverter.convertToToken(
-                    refreshToken.username,
-                    refreshToken.clientId,
-                    refreshToken.scopes
-                )
+                refreshTokenConverter.convertToToken(refreshToken)
         )
 
         tokenStore.storeAccessToken(accessToken)

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/RefreshTokenConverter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/token/converter/RefreshTokenConverter.kt
@@ -3,5 +3,6 @@ package nl.myndocs.oauth2.token.converter
 import nl.myndocs.oauth2.token.RefreshToken
 
 interface RefreshTokenConverter {
+    fun convertToToken(refreshToken: RefreshToken): RefreshToken = convertToToken(refreshToken.username, refreshToken.clientId, refreshToken.scopes)
     fun convertToToken(username: String, clientId: String, requestedScopes: Set<String>): RefreshToken
 }

--- a/oauth2-server-core/src/test/java/nl/myndocs/oauth2/RefreshTokenGrantTokenServiceTest.kt
+++ b/oauth2-server-core/src/test/java/nl/myndocs/oauth2/RefreshTokenGrantTokenServiceTest.kt
@@ -69,7 +69,7 @@ internal class RefreshTokenGrantTokenServiceTest {
         every { clientService.validClient(client, clientSecret) } returns true
         every { tokenStore.refreshToken(refreshToken) } returns token
         every { identityService.identityOf(client, username) } returns identity
-        every { refreshTokenConverter.convertToToken(username, clientId, scopes) } returns newRefreshToken
+        every { refreshTokenConverter.convertToToken(token) } returns newRefreshToken
         every { accessTokenConverter.convertToToken(username, clientId, scopes, newRefreshToken) } returns accessToken
 
         tokenService.refresh(refreshTokenRequest)


### PR DESCRIPTION
Create overloaded refresh token convert method so that the implementor can choose to reuse the refresh token as suggested in the comments of #31 