### PR TITLE
Grant extension

### DIFF
--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/CallRouter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/CallRouter.kt
@@ -5,7 +5,10 @@ import nl.myndocs.oauth2.exception.*
 import nl.myndocs.oauth2.grant.Granter
 import nl.myndocs.oauth2.grant.GrantingCall
 import nl.myndocs.oauth2.identity.TokenInfo
-import nl.myndocs.oauth2.request.*
+import nl.myndocs.oauth2.request.CallContext
+import nl.myndocs.oauth2.request.RedirectAuthorizationCodeRequest
+import nl.myndocs.oauth2.request.RedirectTokenRequest
+import nl.myndocs.oauth2.request.headerCaseInsensitive
 
 class CallRouter(
         private val tokenService: TokenService,
@@ -47,8 +50,7 @@ class CallRouter(
                 override val callContext: CallContext
                     get() = callContext
 
-                override val tokenService: TokenService
-                    get() = tokenService
+                override val tokenService = this@CallRouter.tokenService
             }
 
             val granterMap = mutableMapOf<String, Granter>()

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/CallRouter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/CallRouter.kt
@@ -53,12 +53,12 @@ class CallRouter(
                 override val tokenService = this@CallRouter.tokenService
             }
 
-            val granterMap = mutableMapOf<String, Granter>()
-
-            granters.forEach {
-                val granter = grantingCall.it()
-                granterMap[granter.grantType] = granter
-            }
+            val granterMap = granters
+                    .map {
+                        val granter = grantingCall.it()
+                        granter.grantType to granter
+                    }
+                    .toMap()
 
             val allowedGrantTypes = granterMap.keys
 

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/CallRouter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/CallRouter.kt
@@ -1,21 +1,19 @@
 package nl.myndocs.oauth2
 
 import nl.myndocs.oauth2.authenticator.Authorizer
-import nl.myndocs.oauth2.client.AuthorizedGrantType.AUTHORIZATION_CODE
-import nl.myndocs.oauth2.client.AuthorizedGrantType.CLIENT_CREDENTIALS
-import nl.myndocs.oauth2.client.AuthorizedGrantType.PASSWORD
-import nl.myndocs.oauth2.client.AuthorizedGrantType.REFRESH_TOKEN
 import nl.myndocs.oauth2.exception.*
+import nl.myndocs.oauth2.grant.Granter
+import nl.myndocs.oauth2.grant.GrantingCall
 import nl.myndocs.oauth2.identity.TokenInfo
 import nl.myndocs.oauth2.request.*
-import nl.myndocs.oauth2.token.toMap
 
 class CallRouter(
         private val tokenService: TokenService,
         val tokenEndpoint: String,
         val authorizeEndpoint: String,
         val tokenInfoEndpoint: String,
-        private val tokenInfoCallback: (TokenInfo) -> Map<String, Any?>
+        private val tokenInfoCallback: (TokenInfo) -> Map<String, Any?>,
+        private val granters: List<GrantingCall.() -> Granter>
 ) {
     companion object {
         const val METHOD_POST = "post"
@@ -42,75 +40,36 @@ class CallRouter(
         }
 
         try {
-            val allowedGrantTypes = setOf(PASSWORD, AUTHORIZATION_CODE, REFRESH_TOKEN, CLIENT_CREDENTIALS)
             val grantType = callContext.formParameters["grant_type"]
                     ?: throw InvalidRequestException("'grant_type' not given")
+
+            val grantingCall = object: GrantingCall {
+                override val callContext: CallContext
+                    get() = callContext
+
+                override val tokenService: TokenService
+                    get() = tokenService
+            }
+
+            val granterMap = mutableMapOf<String, Granter>()
+
+            granters.forEach {
+                val granter = grantingCall.it()
+                granterMap[granter.grantType] = granter
+            }
+
+            val allowedGrantTypes = granterMap.keys
 
             if (!allowedGrantTypes.contains(grantType)) {
                 throw InvalidGrantException("'grant_type' with value '$grantType' not allowed")
             }
 
-            when (grantType) {
-                "password" -> routePasswordGrant(callContext, tokenService)
-                "authorization_code" -> routeAuthorizationCodeGrant(callContext, tokenService)
-                "refresh_token" -> routeRefreshTokenGrant(callContext, tokenService)
-                "client_credentials" -> routeClientCredentialsGrant(callContext, tokenService)
-            }
+            granterMap[grantType]!!.callback.invoke()
         } catch (oauthException: OauthException) {
             callContext.respondStatus(STATUS_BAD_REQUEST)
             callContext.respondJson(oauthException.toMap())
         }
     }
-
-    fun routePasswordGrant(callContext: CallContext, tokenService: TokenService) {
-        val tokenResponse = tokenService.authorize(
-                PasswordGrantRequest(
-                        callContext.formParameters["client_id"],
-                        callContext.formParameters["client_secret"],
-                        callContext.formParameters["username"],
-                        callContext.formParameters["password"],
-                        callContext.formParameters["scope"]
-                )
-        )
-
-        callContext.respondJson(tokenResponse.toMap())
-    }
-
-    fun routeClientCredentialsGrant(callContext: CallContext, tokenService: TokenService) {
-        val tokenResponse = tokenService.authorize(ClientCredentialsRequest(
-            callContext.formParameters["client_id"],
-            callContext.formParameters["client_secret"],
-            callContext.formParameters["scope"]
-        ))
-
-        callContext.respondJson(tokenResponse.toMap())
-    }
-
-    fun routeRefreshTokenGrant(callContext: CallContext, tokenService: TokenService) {
-        val accessToken = tokenService.refresh(
-                RefreshTokenRequest(
-                        callContext.formParameters["client_id"],
-                        callContext.formParameters["client_secret"],
-                        callContext.formParameters["refresh_token"]
-                )
-        )
-
-        callContext.respondJson(accessToken.toMap())
-    }
-
-    fun routeAuthorizationCodeGrant(callContext: CallContext, tokenService: TokenService) {
-        val accessToken = tokenService.authorize(
-                AuthorizationCodeRequest(
-                        callContext.formParameters["client_id"],
-                        callContext.formParameters["client_secret"],
-                        callContext.formParameters["code"],
-                        callContext.formParameters["redirect_uri"]
-                )
-        )
-
-        callContext.respondJson(accessToken.toMap())
-    }
-
 
     fun routeAuthorizationCodeRedirect(
             callContext: CallContext,

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/Oauth2TokenService.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/Oauth2TokenService.kt
@@ -20,12 +20,12 @@ import nl.myndocs.oauth2.token.converter.CodeTokenConverter
 import nl.myndocs.oauth2.token.converter.RefreshTokenConverter
 
 class Oauth2TokenService(
-        private val identityService: IdentityService,
-        private val clientService: ClientService,
-        private val tokenStore: TokenStore,
-        private val accessTokenConverter: AccessTokenConverter,
-        private val refreshTokenConverter: RefreshTokenConverter,
-        private val codeTokenConverter: CodeTokenConverter
+        val identityService: IdentityService,
+        val clientService: ClientService,
+        val tokenStore: TokenStore,
+        val accessTokenConverter: AccessTokenConverter,
+        val refreshTokenConverter: RefreshTokenConverter,
+        val codeTokenConverter: CodeTokenConverter
 ) : TokenService {
     private val INVALID_REQUEST_FIELD_MESSAGE = "'%s' field is missing"
     /**

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/Oauth2TokenService.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/Oauth2TokenService.kt
@@ -20,12 +20,12 @@ import nl.myndocs.oauth2.token.converter.CodeTokenConverter
 import nl.myndocs.oauth2.token.converter.RefreshTokenConverter
 
 class Oauth2TokenService(
-        val identityService: IdentityService,
-        val clientService: ClientService,
-        val tokenStore: TokenStore,
-        val accessTokenConverter: AccessTokenConverter,
-        val refreshTokenConverter: RefreshTokenConverter,
-        val codeTokenConverter: CodeTokenConverter
+        private val identityService: IdentityService,
+        private val clientService: ClientService,
+        private val tokenStore: TokenStore,
+        private val accessTokenConverter: AccessTokenConverter,
+        private val refreshTokenConverter: RefreshTokenConverter,
+        private val codeTokenConverter: CodeTokenConverter
 ) : TokenService {
     private val INVALID_REQUEST_FIELD_MESSAGE = "'%s' field is missing"
     /**

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/config/CallRouterBuilder.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/config/CallRouterBuilder.kt
@@ -1,7 +1,7 @@
 package nl.myndocs.oauth2.config
 
-import nl.myndocs.oauth2.CallRouter
-import nl.myndocs.oauth2.TokenService
+import nl.myndocs.oauth2.*
+import nl.myndocs.oauth2.grant.*
 import nl.myndocs.oauth2.identity.TokenInfo
 
 internal object CallRouterBuilder {
@@ -16,6 +16,7 @@ internal object CallRouterBuilder {
             ).filterValues { it != null }
         }
         var tokenService: TokenService? = null
+        var granters: List<GrantingCall.() -> Granter> = listOf()
     }
 
     fun build(configurer: Configuration.() -> Unit): CallRouter {
@@ -30,6 +31,12 @@ internal object CallRouterBuilder {
             configuration.tokenEndpoint,
             configuration.authorizeEndpoint,
             configuration.tokenInfoEndpoint,
-            configuration.tokenInfoCallback
+            configuration.tokenInfoCallback,
+            listOf<GrantingCall.() -> Granter>(
+                    { grantPassword() },
+                    { grantAuthorizationCode() },
+                    { grantClientCredentials() },
+                    { grantRefreshToken() }
+            ) + configuration.granters
     )
 }

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/config/ConfigurationBuilder.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/config/ConfigurationBuilder.kt
@@ -2,6 +2,8 @@ package nl.myndocs.oauth2.config
 
 import nl.myndocs.oauth2.TokenService
 import nl.myndocs.oauth2.authenticator.Authorizer
+import nl.myndocs.oauth2.grant.Granter
+import nl.myndocs.oauth2.grant.GrantingCall
 import nl.myndocs.oauth2.identity.TokenInfo
 import nl.myndocs.oauth2.request.CallContext
 import nl.myndocs.oauth2.request.auth.BasicAuthorizer
@@ -38,6 +40,12 @@ object ConfigurationBuilder {
             get() = callRouterConfiguration.tokenInfoCallback
             set(value) {
                 callRouterConfiguration.tokenInfoCallback = value
+            }
+
+        var granters: List<GrantingCall.() -> Granter>
+            get() = callRouterConfiguration.granters
+            set(value) {
+                callRouterConfiguration.granters = value
             }
 
         var authorizerFactory: (CallContext) -> Authorizer = ::BasicAuthorizer

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/CallRouterDefault.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/CallRouterDefault.kt
@@ -1,0 +1,53 @@
+package nl.myndocs.oauth2.grant
+
+import nl.myndocs.oauth2.request.*
+import nl.myndocs.oauth2.token.toMap
+
+fun GrantingCall.grantPassword() = granter("password") {
+    val tokenResponse = tokenService.authorize(
+            PasswordGrantRequest(
+                    callContext.formParameters["client_id"],
+                    callContext.formParameters["client_secret"],
+                    callContext.formParameters["username"],
+                    callContext.formParameters["password"],
+                    callContext.formParameters["scope"]
+            )
+    )
+
+    callContext.respondJson(tokenResponse.toMap())
+}
+
+fun GrantingCall.grantClientCredentials() = granter("client_credentials") {
+    val tokenResponse = tokenService.authorize(ClientCredentialsRequest(
+            callContext.formParameters["client_id"],
+            callContext.formParameters["client_secret"],
+            callContext.formParameters["scope"]
+    ))
+
+    callContext.respondJson(tokenResponse.toMap())
+}
+
+fun GrantingCall.grantRefreshToken() = granter("refresh_token") {
+    val accessToken = tokenService.refresh(
+            RefreshTokenRequest(
+                    callContext.formParameters["client_id"],
+                    callContext.formParameters["client_secret"],
+                    callContext.formParameters["refresh_token"]
+            )
+    )
+
+    callContext.respondJson(accessToken.toMap())
+}
+
+fun GrantingCall.grantAuthorizationCode() = granter("authorization_code") {
+    val accessToken = tokenService.authorize(
+            AuthorizationCodeRequest(
+                    callContext.formParameters["client_id"],
+                    callContext.formParameters["client_secret"],
+                    callContext.formParameters["code"],
+                    callContext.formParameters["redirect_uri"]
+            )
+    )
+
+    callContext.respondJson(accessToken.toMap())
+}

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/GrantBuilder.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/GrantBuilder.kt
@@ -1,0 +1,3 @@
+package nl.myndocs.oauth2.grant
+
+fun granter(grantType: String, callback: () -> Unit) = Granter(grantType, callback)

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/Granter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/Granter.kt
@@ -1,0 +1,6 @@
+package nl.myndocs.oauth2.grant
+
+class Granter(
+    val grantType: String,
+    val callback: () -> Unit
+)

--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/GrantingCall.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/GrantingCall.kt
@@ -1,0 +1,9 @@
+package nl.myndocs.oauth2.grant
+
+import nl.myndocs.oauth2.TokenService
+import nl.myndocs.oauth2.request.CallContext
+
+interface GrantingCall {
+    val callContext: CallContext
+    val tokenService: TokenService
+}


### PR DESCRIPTION
The ability to create extension grants (#43). By adding `GrantingCall`.
`TokenService` now exposes the dependencies which is required to perform its task. This should give the implementer all the tools it needs to create a custom granter:

A granter can be defined like so: 
```
fun GrantingCall.grantPassword() = granter("password") {
    val tokenResponse = tokenService.authorize(
            PasswordGrantRequest(
                    callContext.formParameters["client_id"],
                    callContext.formParameters["client_secret"],
                    callContext.formParameters["username"],
                    callContext.formParameters["password"],
                    callContext.formParameters["scope"]
            )
    )

    callContext.respondJson(tokenResponse.toMap())
}
```

And it could be registered like so:
```
tokenService = Oauth2TokenServiceBuilder.build {
        // ... other configuration ...
	granters = listOf<GrantingCall.() -> Granter>(
		{ grantPassword() }
	)
}
```