### PR TITLE
Add Cache-Control and Pragma headers to Access Token responses

### DIFF
--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/CallRouterDefault.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/grant/CallRouterDefault.kt
@@ -21,6 +21,8 @@ fun GrantingCall.grantPassword() = granter("password") {
             )
     )
 
+    callContext.respondHeader("Cache-Control", "no-store")
+    callContext.respondHeader("Pragma", "no-cache")
     callContext.respondJson(accessTokenResponder.createResponse(accessToken))
 }
 
@@ -31,6 +33,8 @@ fun GrantingCall.grantClientCredentials() = granter("client_credentials") {
             callContext.formParameters["scope"]
     ))
 
+    callContext.respondHeader("Cache-Control", "no-store")
+    callContext.respondHeader("Pragma", "no-cache")
     callContext.respondJson(accessTokenResponder.createResponse(accessToken))
 }
 
@@ -43,6 +47,8 @@ fun GrantingCall.grantRefreshToken() = granter("refresh_token") {
             )
     )
 
+    callContext.respondHeader("Cache-Control", "no-store")
+    callContext.respondHeader("Pragma", "no-cache")
     callContext.respondJson(accessTokenResponder.createResponse(accessToken))
 }
 
@@ -56,6 +62,8 @@ fun GrantingCall.grantAuthorizationCode() = granter("authorization_code") {
             )
     )
 
+    callContext.respondHeader("Cache-Control", "no-store")
+    callContext.respondHeader("Pragma", "no-cache")
     callContext.respondJson(accessTokenResponder.createResponse(accessToken))
 }
 


### PR DESCRIPTION
See section [5.1 Successful Response](https://tools.ietf.org/html/rfc6749#section-5.1)

>   The authorization server MUST include the HTTP "Cache-Control"
>   response header field [RFC2616] with a value of "no-store" in any
>   response containing tokens, credentials, or other sensitive
>   information, as well as the "Pragma" response header field [RFC2616]
>   with a value of "no-cache".