### PR TITLE
return 401 (Unauthorized) header when missing credentials in request

### DIFF
--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/CallRouter.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/CallRouter.kt
@@ -160,6 +160,10 @@ class CallRouter(
                 "token" -> routeAccessTokenRedirect(callContext, credentials)
                 else -> throw InvalidGrantException("'grant_type' with value '$responseType' not allowed")
             }
+        } catch (invalidIdentityException: InvalidIdentityException) {
+            callContext.respondStatus(STATUS_UNAUTHORIZED)
+            callContext.respondJson(invalidIdentityException.toMap())
+            return RedirectRouterResponse(false)
         } catch (oauthException: OauthException) {
             callContext.respondStatus(STATUS_BAD_REQUEST)
             callContext.respondJson(oauthException.toMap())


### PR DESCRIPTION
In case of missing credentials in request to tokenEndpooint server should response with 401 code. With 401 response code browser will open up credentials screen. 