### PR TITLE
Bump Javalin and Jackson versions to support current Javalin version

### DIFF
--- a/oauth2-server-core/src/main/java/nl/myndocs/oauth2/scope/ScopeParser.kt
+++ b/oauth2-server-core/src/main/java/nl/myndocs/oauth2/scope/ScopeParser.kt
@@ -5,7 +5,7 @@ object ScopeParser {
 
     fun parseScopes(scopes: String?): Set<String> {
         if (!scopes.isNullOrBlank()) {
-            return scopes!!.split(SCOPE_SEPARATOR)
+            return scopes.split(SCOPE_SEPARATOR)
                     .toSet()
         }
 

--- a/oauth2-server-integration-base/pom.xml
+++ b/oauth2-server-integration-base/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>oauth2-server-integration-base</artifactId>
 
     <properties>
-        <jackson.version>2.9.9</jackson.version>
-        <jackson.databind.version>2.10.0.pr1</jackson.databind.version>
+        <jackson.version>2.11.4</jackson.version>
+        <jackson.databind.version>2.11.4</jackson.databind.version>
     </properties>
 
     <dependencies>

--- a/oauth2-server-javalin/pom.xml
+++ b/oauth2-server-javalin/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>
-            <version>2.0.0</version>
+            <version>3.12.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/oauth2-server-javalin/src/main/java/nl/myndocs/oauth2/javalin/Oauth2Server.kt
+++ b/oauth2-server-javalin/src/main/java/nl/myndocs/oauth2/javalin/Oauth2Server.kt
@@ -1,11 +1,10 @@
 package nl.myndocs.oauth2.javalin
 
-import io.javalin.Context
+import io.javalin.http.Context
 import io.javalin.Javalin
 import io.javalin.apibuilder.ApiBuilder.*
 import nl.myndocs.oauth2.config.ConfigurationBuilder
 import nl.myndocs.oauth2.javalin.request.JavalinCallContext
-import nl.myndocs.oauth2.request.auth.BasicAuthenticator
 import nl.myndocs.oauth2.request.auth.CallContextBasicAuthenticator
 import nl.myndocs.oauth2.router.RedirectRouter
 

--- a/oauth2-server-javalin/src/main/java/nl/myndocs/oauth2/javalin/request/JavalinCallContext.kt
+++ b/oauth2-server-javalin/src/main/java/nl/myndocs/oauth2/javalin/request/JavalinCallContext.kt
@@ -1,10 +1,9 @@
 package nl.myndocs.oauth2.javalin.request
 
-import io.javalin.Context
-import nl.myndocs.oauth2.authenticator.Credentials
+import io.javalin.http.Context
 import nl.myndocs.oauth2.request.CallContext
 
-class JavalinCallContext(val context: Context) : CallContext {
+class JavalinCallContext(private val context: Context) : CallContext {
     override val path: String = context.path()
     override val method: String = context.method()
     override val headers: Map<String, String> = context.headerMap()

--- a/oauth2-server-javalin/src/test/java/nl/myndocs/oauth2/javalin/integration/JavalinIntegrationTest.kt
+++ b/oauth2-server-javalin/src/test/java/nl/myndocs/oauth2/javalin/integration/JavalinIntegrationTest.kt
@@ -8,17 +8,16 @@ import org.junit.jupiter.api.BeforeEach
 
 class JavalinIntegrationTest : BaseIntegrationTest() {
 
-    val server = Javalin.create()
+    private val server: Javalin = Javalin.create()
             .apply {
                 enableOauthServer {
                     configBuilder(this)
                 }
             }
-            .port(0)
 
     @BeforeEach
     fun before() {
-        server.start()
+        server.start(0)
 
         localPort = server.port()
     }


### PR DESCRIPTION
Good afternoon. 

I've created this pull request because I'm trying to create a mock server for a very specific usage, but I wasn't able to properly use your current version of Javalin, since it's pointing to Javalin 2, and some namespaces were changed in the meantime.

Thanks in advance. 